### PR TITLE
Bang operator will not work on :name of person class now

### DIFF
--- a/14/dont_modify.rb
+++ b/14/dont_modify.rb
@@ -1,0 +1,19 @@
+# class
+class Person
+  attr_writer :name
+
+  def initialize(name)
+    @name = name
+  end
+
+  def name
+    @name.clone
+  end
+end
+
+person1 = Person.new('James')
+
+person1.name = 'Haider'
+
+person1.name.reverse!
+puts person1.name


### PR DESCRIPTION
The following code is flawed. It currently allows @name to be modified from outside the method via a destructive method call. Fix the code so that it returns a copy of @name instead of a reference to it.
class Person
  attr_reader :name

  def initialize(name)
    @name = name
  end
end

person1 = Person.new('James')
person1.name.reverse!
puts person1.name

OUTPUT: James
