### PR TITLE
attr_accessor is removed to prevent outside world to access phone_number

### DIFF
--- a/10/main.rb
+++ b/10/main.rb
@@ -1,0 +1,13 @@
+# frozen_string-literal: true
+
+# class
+class Person
+  def initialize(number)
+    @phone_number = number
+  end
+end
+
+person1 = Person.new(1_234_567_899)
+
+person1.phone_number = 9_987_654_321
+# puts person1.phone_number


### PR DESCRIPTION
Modify code to stop access of phone_number method from outside world
class Person
  attr_accessor :phone_number

  def initialize(number)
    @phone_number = number
  end
end

person1 = Person.new(1234567899)
puts person1.phone_number #OUTPUT: 1234567899
# After Modification
person1.phone_number = 9987654321
puts person1.phone_number #OUTPUT NoMethodError
